### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Register at https://coinmarketcap.com/api/pricing/ and paste API key in this dir
 
   
 
-`examples/cmc/.spin/CMC_API_KEY`
+`examples/cmc/spin.toml`
 
   
 


### PR DESCRIPTION
Fix outdated instructions so that now they tell the reader to put CMC key in spin.toml, which is the same for YF.